### PR TITLE
Nullable ChargeResponse object cast

### DIFF
--- a/lib/widgets/home/flutterwave_payment.dart
+++ b/lib/widgets/home/flutterwave_payment.dart
@@ -416,7 +416,7 @@ class _FlutterwaveUIState extends State<FlutterwaveUI> {
 
   void _handleBackPress(dynamic result) {
     if (result == null || result is ChargeResponse){
-      final ChargeResponse? chargeResponse = result as ChargeResponse;
+      final ChargeResponse? chargeResponse = result as ChargeResponse?;
       String message;
       if (chargeResponse != null) {
         message = chargeResponse.message!;


### PR DESCRIPTION
If the chargeResponse object is null (i.e payment was not initiated/cancelled by the customer) the cast throws an error.