### PR TITLE
Fix context issue on showConfirmPaymentModal

### DIFF
--- a/lib/widgets/card_payment/card_payment.dart
+++ b/lib/widgets/card_payment/card_payment.dart
@@ -199,8 +199,6 @@ class _CardPaymentState extends State<CardPayment>
   }
 
   void _makeCardPayment() {
-    Navigator.of(this.context).pop();
-
     this._showLoading(FlutterwaveConstants.INITIATING_PAYMENT);
 
     final ChargeCardRequest chargeCardRequest = ChargeCardRequest(

--- a/lib/widgets/flutterwave_view_utils.dart
+++ b/lib/widgets/flutterwave_view_utils.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 
 class FlutterwaveViewUtils {
-
   /// Displays a modal to confirm payment
-  static Future<void> showConfirmPaymentModal(final BuildContext context,
-      final String currency, final String amount, final Function onContinuePressed) async {
+  static Future<void> showConfirmPaymentModal(
+      final BuildContext context,
+      final String currency,
+      final String amount,
+      final Function onContinuePressed) async {
     return showDialog(
       context: context,
       barrierDismissible: false,
@@ -26,20 +28,22 @@ class FlutterwaveViewUtils {
           actions: [
             //Changed Continue to the right as confirmation buttons tend to be on the right for better UX.
             FlatButton(
-              onPressed: () => {Navigator.of(context).pop()},
+              onPressed: () => {Navigator.of(buildContext).pop()},
               child: Text(
                 "CANCEL",
                 style: TextStyle(fontSize: 16, letterSpacing: 1),
               ),
             ),
             FlatButton(
-              onPressed: () => onContinuePressed(),
+              onPressed: () {
+                Navigator.of(buildContext).pop();
+                onContinuePressed();
+              },
               child: Text(
                 "CONTINUE",
                 style: TextStyle(fontSize: 16, letterSpacing: 1),
               ),
             ),
-
           ],
         );
       },


### PR DESCRIPTION
Closing the modal when you press either  continue or cancel crashes the application as it passes the main context instead of the modals context.  This fix passes the correct context to close the modal instead.